### PR TITLE
modified menu highlight strategy

### DIFF
--- a/src/AdminBundle/Resources/views/Groups/manage.html.twig
+++ b/src/AdminBundle/Resources/views/Groups/manage.html.twig
@@ -6,22 +6,12 @@
 
     {% import 'AdminBundle:Users:macros.html.twig' as usersMacros %}
 
-    <div id="tabs">
-        <ul class="nav nav-tabs">
-            <li class="active"><a href="#manage-users" data-toggle="tab">{{ 'base.menu.admin.users'|trans }}</a></li>
-        </ul>
-        <div class="tab-content">
-            <div class="tab-pane active" id="manage-users">
-                <h2>{{ 'admin.groups_manage.users'|trans }}</h2>
-                <div class="row">
-                    <div class="col-md-6">
-                        {{ usersMacros.displayUsers('groups', group.id, group.name, usersIn, 'in') }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ usersMacros.displayUsers('groups', group.id, group.name, usersOut, 'out') }}
-                    </div>
-                </div>
-            </div>
+    <div class="row">
+        <div class="col-md-6">
+            {{ usersMacros.displayUsers('groups', group.id, group.name, usersIn, 'in') }}
+        </div>
+        <div class="col-md-6">
+            {{ usersMacros.displayUsers('groups', group.id, group.name, usersOut, 'out') }}
         </div>
     </div>
 

--- a/src/AdminBundle/Resources/views/Users/manage.html.twig
+++ b/src/AdminBundle/Resources/views/Users/manage.html.twig
@@ -6,22 +6,12 @@
 
     {% import 'AdminBundle:Groups:macros.html.twig' as groupsMacros %}
 
-    <div id="tabs">
-        <ul class="nav nav-tabs">
-            <li class="active"><a href="#manage-groups" data-toggle="tab">{{ 'base.menu.admin.groups'|trans }}</a></li>
-        </ul>
-        <div class="tab-content">
-            <div class="tab-pane active" id="manage-groups">
-                <h2>{{ 'admin.users_manage.groups'|trans }}</h2>
-                <div class="row">
-                    <div class="col-md-6">
-                        {{ groupsMacros.displayGroups('users', user.id, user.nickname, groupsIn, 'in') }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ groupsMacros.displayGroups('users', user.id, user.nickname, groupsOut, 'out') }}
-                    </div>
-                </div>
-            </div>
+    <div class="row">
+        <div class="col-md-6">
+            {{ groupsMacros.displayGroups('users', user.id, user.nickname, groupsIn, 'in') }}
+        </div>
+        <div class="col-md-6">
+            {{ groupsMacros.displayGroups('users', user.id, user.nickname, groupsOut, 'out') }}
         </div>
     </div>
 

--- a/src/AppBundle/Menu/Builder.php
+++ b/src/AppBundle/Menu/Builder.php
@@ -21,7 +21,7 @@ class Builder extends BaseMenu
           $this->addRoute($menu['test'], 'testC', 'testc');
         */
 
-        return $menu;
+        return $this->selectActiveMenu($menu);
     }
 
     public function mainRightMenu(FactoryInterface $factory, array $options)
@@ -34,6 +34,6 @@ class Builder extends BaseMenu
             $this->addRoute($menu['base.menu.admin.main'], 'base.menu.admin.groups', 'admin_groups');
         }
 
-        return $menu;
+        return $this->selectActiveMenu($menu);
     }
 }


### PR DESCRIPTION
The "Manage users" menu links to /admin/users
But if I want to manage Bob user (id = 3), I end up here: /admin/users/manage/3
As there was no direct match with the menu, "Administration" weren't active anymore.

This PR changes the strategy. See #8 for more details