### PR TITLE
better layout according to the number of enabled providers

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -96,6 +96,7 @@ braincrafted_bootstrap:
       knp_menu: false
 
 # HWIOAuthBundle Configuration
+# Don't forget to add new resource owners to twig > globals > services configuration
 hwi_oauth:
     firewall_names: ["main"]
     resource_owners:

--- a/src/BaseBundle/Resources/views/layout.html.twig
+++ b/src/BaseBundle/Resources/views/layout.html.twig
@@ -39,16 +39,30 @@
                <li><a href="{{ path('logout') }}">{{ 'base.logout.title' | trans }}</a></li>
             {% endblock %}
         {% else %}
-           {% block logged_out %}
-               <li class="dropdown">
-                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ 'base.login.title' | trans }} <span class="caret"></span></a>
-                   <ul class="dropdown-menu" role="menu">
-                       {% for service, enabled in fuz.services if enabled %}
-                           {% set serviceId = (service|split(' '))[0]|lower %}
-                           <li><a href="{{ hwi_oauth_login_url(serviceId) }}"><img class="oauth-image" src="{{ asset('bundles/base/img/oauth/' ~ serviceId ~ '-small.png') }}" alt=""/> {{ service }}</a></li>
-                       {% endfor %}
-                   </ul>
-               </li>
+            {% block logged_out %}
+                {% set servicesCount = 0 %}
+                {% for service, enabled in fuz.services if enabled %}
+                    {% set servicesCount = servicesCount + 1 %}
+                {% endfor %}
+
+                {% if servicesCount > 0 %}
+                    {% if servicesCount > 1 %}
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ 'base.login.title' | trans }} <span class="caret"></span></a>
+                            <ul class="dropdown-menu" role="menu">
+                    {% endif %}
+
+                    {% for service, enabled in fuz.services if enabled %}
+                        {% set serviceId = (service|split(' '))[0]|lower %}
+                        <li><a href="{{ hwi_oauth_login_url(serviceId) }}"><img class="oauth-image" src="{{ asset('bundles/base/img/oauth/' ~ serviceId ~ '-small.png') }}" alt=""/> {{ service }}</a></li>
+                    {% endfor %}
+
+                    {% if servicesCount > 1 %}
+                            </ul>
+                        </li>
+                    {% endif %}
+
+                {% endif %}
             {% endblock %}
         {% endif %}
     </ul>


### PR DESCRIPTION
If no provider are enabled, there are no menu at all

If one provider is enabled, it appears directly in the top-right of the screen

If several providers are enabled, the current behavior (a Connect menu) appears

See #8 for more details